### PR TITLE
fix: region name in resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You'll need to have Terraform & the AWS CLI installed locally, and an OKTA accou
     * export OKTA_BASE_URL=okta.com
     * export OKTA_API_TOKEN=12345678979654645646556
 
+If needed, read here [how to create an Okta API Token](https://bit.ly/get-okta-api-token).
 
 Run:
 

--- a/terraform/backend/modules.tf
+++ b/terraform/backend/modules.tf
@@ -2,6 +2,7 @@ module "identifiers" {
   source = "./../modules/identifiers"
 
   aws_account_id = local.aws_account_id
+  aws_region     = var.aws_region
   env            = var.env
   github_repo    = var.github_repo
   owner          = var.owner

--- a/terraform/frontend/modules.tf
+++ b/terraform/frontend/modules.tf
@@ -2,6 +2,7 @@ module "identifiers" {
   source = "./../modules/identifiers"
 
   aws_account_id = local.aws_account_id
+  aws_region     = var.aws_region
   env            = var.env
   github_repo    = var.github_repo
   owner          = var.owner


### PR DESCRIPTION
When deploying the resources to AWS, Terraform adds some values to the resource names to better identify the origin of the resources.

Service names are prefixed with `${local.service_name}-${var.env}-${var.aws_region}` which might become `serverless-voting-app-test-eu-west-1` at deploy time.

This value is defined in `terraform/modules/identifiers/main.ts`, which in turn sources it from `terraform/modules/identifiers/variables.tf`. While the value is correctly captured when running one of the bash scripts, the other modules (i.e. `backend` & `frontend`) were not properly being passed the variable, causing it to always use the default value of `eu-central-1` even when the user specified a different region.

Below a screenshot that shows how the resources were deployed in the correct region, but had a value corresponding to another one in the name:
![Screenshot 2022-08-25 at 10 14 51](https://user-images.githubusercontent.com/7353869/186618440-12e25ba8-ee84-4100-903e-1c782d5937df.png)

This PR modifies `terraform/backend/modules.tf` & `terraform/frontend/modules.tf` so that they use the value specified by the user. After the changes the resources are named correctly:
![Screenshot 2022-08-25 at 10 27 04](https://user-images.githubusercontent.com/7353869/186618726-2561c785-f861-468c-a789-c133e2f7c456.png)

Finally, for housekeeping, the PR also adds to the README a link to the Okta docs that show how to create an API token.