### PR TITLE
Fixing bugs when deploying to the secondary region

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ chmod +x ./scripts/deploy-state.sh
 ./scripts/deploy-state.sh apply
 ```
 
-2) Deploy the app (including OKTA):
+2) Deploy the app on the primary region (including OKTA):
 ```shell
 chmod +x ./scripts/deploy.sh
 ./scripts/deploy.sh apply
+# Enter the parameters. The second parameter (region) must be eu-central-1 (primary region)
 ```
+
+3) Deploy the app on the secondary region
+
+```shell
+./scripts/deploy.sh apply
+# Enter the parameters. The second parameter (region) must be us-east-1 (secondary region)
+```
+If you want to change the primary/secondary regions, search for `eu-central-1` and `us-east-1` in the whole project and replace all of them. 
 
 ### Architecture
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,7 +19,7 @@ function main {
     setDeploymentConfig
     introComments "$@"
 
-    npm ci "--production"
+    npm install "--include=dev"
     npm run build
     mkdir -p dist/backend
     cd dist/backend
@@ -40,7 +40,6 @@ function main {
         echo "Above you can see the planned changes. To apply those changes run './scripts/deploy.sh apply' "
     fi
 
-    npm install "--include=dev"
 }
 
 main "${*}"

--- a/terraform/cross-region-infra/dynamodb-global-tables.tf
+++ b/terraform/cross-region-infra/dynamodb-global-tables.tf
@@ -6,7 +6,6 @@ resource "aws_dynamodb_table" "videos_primary" {
   # provider = "aws.${local.primary_region}"
   provider = aws.eu-central-1
 
-  count = local.is_primary ? 1 : 0
   name         = local.dynamodb_videos_resource_name
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
@@ -41,7 +40,6 @@ resource "aws_dynamodb_table" "videos_primary" {
 resource "aws_dynamodb_table" "videos_secondary" {
   provider = aws.us-east-1
 
-  count = local.is_primary ? 1 : 0
   name         = local.dynamodb_videos_resource_name
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
@@ -101,7 +99,6 @@ resource "aws_dynamodb_table" "votes_primary" {
   # provider = "aws.${local.primary_region}"
   provider = aws.eu-central-1
 
-  count = local.is_primary ? 1 : 0
   name         = local.dynamodb_votes_resource_name
   billing_mode = "PAY_PER_REQUEST"
   stream_enabled   = true
@@ -127,7 +124,6 @@ resource "aws_dynamodb_table" "votes_primary" {
 resource "aws_dynamodb_table" "votes_secondary" {
   provider = aws.us-east-1
 
-  count = local.is_primary ? 1 : 0
   name         = local.dynamodb_votes_resource_name
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"

--- a/terraform/cross-region-infra/locals.tf
+++ b/terraform/cross-region-infra/locals.tf
@@ -17,6 +17,7 @@ locals {
 
   dynamodb_displayed_videos_index_name = "displayedVideosIndex"
 
-  dynamodb_videos_resource_name   = "${local.verbose_service_name}-videos-global-${local.stack_name_postfix}"
-  dynamodb_votes_resource_name    = "${local.verbose_service_name}-votes-global-${local.stack_name_postfix}"
+  # The name has to always the same or the resources will be deleted when deploying on the secondary region
+  dynamodb_videos_resource_name   = "${local.service_name}-${var.env}-${local.primary_region}-videos-global-${local.stack_name_postfix}"
+  dynamodb_votes_resource_name    = "${local.service_name}-${var.env}-${local.primary_region}-votes-global-${local.stack_name_postfix}"
 }

--- a/terraform/cross-region-infra/modules.tf
+++ b/terraform/cross-region-infra/modules.tf
@@ -2,7 +2,7 @@ module "identifiers" {
   source = "./../modules/identifiers"
 
   aws_account_id = local.aws_account_id
-  aws_region     = var.aws_region
+  aws_region     = local.primary_region
   env            = var.env
   github_repo    = var.github_repo
   owner          = var.owner

--- a/terraform/okta/main.tf
+++ b/terraform/okta/main.tf
@@ -9,6 +9,7 @@ resource "okta_app_oauth" "single_page_app" {
   label                      = local.okta_app_resource_name
   type                       = "browser"
   token_endpoint_auth_method = "none"
+  pkce_required              = true
   grant_types                = ["authorization_code", "refresh_token"]
   response_types             = ["code"]
   redirect_uris              = ["https://${local.cloudfront_distribution_alias}/callback"]
@@ -26,7 +27,7 @@ resource "okta_app_group_assignment" "everyone_group_assignment" {
 }
 
 resource "okta_trusted_origin" "website_origin" {
-  name   = local.okta_app_resource_name
+  name   = "${local.okta_app_resource_name}-${var.aws_region}"
   origin = "https://${local.cloudfront_distribution_alias}"
   scopes = ["REDIRECT"]
 }


### PR DESCRIPTION
Changes:
1. If we run `./script/deploy.sh`(without "apply"), the TF_VAR won't be passed from `cross-region-infra` to others.  This result in an error that some input (var) are not initalized automatically. 
2. When deploying to the secondary region, it will delete all of the cross-region resources as the `count` is set to 0.  This is fixed by removing count and forcing the AWS's `provider` to always be the primary region.  Terraform will result in "No change" when running in other regions.
3. Use `--raw` to avoid trailing `"`
4. Remove unnecesssary `"\n"` when echoing the outputs 
5. Fix an error that `pkce_required` variable is not set.